### PR TITLE
fixes responsive layout for navbar and body elements on Landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9708,9 +9708,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/src/Pages/Home/home.css
+++ b/src/Pages/Home/home.css
@@ -1,20 +1,24 @@
-.container {
+.App .container {
 	max-width: 1100px;
 	width: 100%;
 	display: grid;
 	grid-template-columns: auto auto;
+	align-items: center;
+	margin: 1rem;
+	gap: 2rem;
 }
 .caption {
 	color: white;
-	margin: 1rem;
 	padding-right: 2rem;
+	display: grid;
 }
 .visualImg {
-	max-width: 400px;
 	width: 100%;
+	max-width: 400px;
 	height: 400px;
 }
 .actionButton {
+	justify-self: start;
 	margin-top: 1.5rem;
 	padding: 15px;
 	background-color: #d4c824;
@@ -23,4 +27,15 @@
 	border: none;
 	border-radius: 0.5rem;
 	cursor: pointer;
+}
+
+@media (max-width: 768px) {
+	.App .container {
+		grid-template-columns: 1fr;
+		margin-top: 3rem;
+	}
+	
+	.visualImg {
+		margin: 0 auto;
+	}
 }

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -1,17 +1,14 @@
 .Navbar {
 	width: 100%;
 	background-color: #d4c824;
-	height: 4rem;
 }
-.container {
+.Navbar .container {
 	max-width: 1100px;
-	width: 100%;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding-top: 0.8rem;
+	padding: 0.8rem;
 	margin: 0 auto;
-	flex-wrap: wrap;
 }
 a {
 	text-decoration: none;
@@ -21,7 +18,13 @@ a {
 }
 .navItems {
 	font-size: 1.5rem;
+	text-align: end;
 }
-.linear {
-	margin-right: 1rem;
+
+.navItems a {
+	display: inline-block;
+}
+
+.binary {
+	margin-left: 1rem;
 }

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -13,7 +13,7 @@ function Navbar() {
 					<Link to="/linearsearch" className="linear">
 						LinearSearch
 					</Link>
-					<Link to="/binarysearch">BinarySearch</Link>
+					<Link to="/binarysearch" className="binary">BinarySearch</Link>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
fixes #14 
Added more specificity to container classes, img shrinks and repositions below main text at 768px page break, Navbar left items wrap once the screen is small enough. Hope it suits your requirements!


![image](https://user-images.githubusercontent.com/36734796/95198574-d2ab9c80-07b1-11eb-856c-9a0af3c3cc9f.png)
